### PR TITLE
Preserve user-customized p/i/.htaccess and .htpasswd across ZIP updates

### DIFF
--- a/scripts/update_util.php
+++ b/scripts/update_util.php
@@ -151,7 +151,7 @@ function save_custom_themes($destination) {
 
 
 // Preserve custom auth files to not delete them
-function save_custom_auth($destination) {
+function save_custom_auth(string $destination) {
 	$auth_dir = PUBLIC_PATH . '/i';
 	foreach (['.htaccess', '.htpasswd'] as $filename) {
 		$src = $auth_dir . '/' . $filename;

--- a/scripts/update_util.php
+++ b/scripts/update_util.php
@@ -157,7 +157,7 @@ function save_custom_auth($destination) {
 		$src = $auth_dir . '/' . $filename;
 		if (is_file($src)) {
 			$dst = $destination . '/' . $filename;
-			$mode = fileperms($src) & 0777;
+			$mode = fileperms($src) & 0777;	// Mask to keep only the permission bits
 			copy($src, $dst);
 			chmod($dst, $mode);  // copy() does not preserve mode
 		}

--- a/scripts/update_util.php
+++ b/scripts/update_util.php
@@ -150,6 +150,21 @@ function save_custom_themes($destination) {
 }
 
 
+// Preserve custom auth files to not delete them
+function save_custom_auth($destination) {
+	$auth_dir = PUBLIC_PATH . '/i';
+	foreach (array('.htaccess', '.htpasswd') as $filename) {
+		$src = $auth_dir . '/' . $filename;
+		if (is_file($src)) {
+			$dst = $destination . '/' . $filename;
+			$mode = fileperms($src) & 0777;
+			copy($src, $dst);
+			chmod($dst, $mode);  // copy() does not preserve mode
+		}
+	}
+}
+
+
 // Deploy FreshRSS package by replacing old version by the new one.
 function deploy_package() {
 	$base_pathname = array_pop(array_diff(scandir(PACKAGE_PATHNAME),
@@ -157,6 +172,7 @@ function deploy_package() {
 	$base_pathname = PACKAGE_PATHNAME . '/' . $base_pathname;
 
 	save_custom_themes($base_pathname . '/p/themes');
+	save_custom_auth($base_pathname . '/p/i');
 
 	// Remove old version.
 	del_tree(APP_PATH);

--- a/scripts/update_util.php
+++ b/scripts/update_util.php
@@ -153,7 +153,7 @@ function save_custom_themes($destination) {
 // Preserve custom auth files to not delete them
 function save_custom_auth($destination) {
 	$auth_dir = PUBLIC_PATH . '/i';
-	foreach (array('.htaccess', '.htpasswd') as $filename) {
+	foreach (['.htaccess', '.htpasswd'] as $filename) {
 		$src = $auth_dir . '/' . $filename;
 		if (is_file($src)) {
 			$dst = $destination . '/' . $filename;


### PR DESCRIPTION
Fixes FreshRSS/FreshRSS#6584

## Problem

`deploy_package()` calls `del_tree(PUBLIC_PATH)` before `recurse_copy(... '/p', PUBLIC_PATH)`, which removes any user-created file under `p/` - including the `p/i/.htaccess` used for HTTP-auth setups (LDAP, htpasswd, etc.) documented at https://freshrss.github.io/FreshRSS/en/admins/09_AccessControl.html. Users with HTTP-auth are locked out immediately after the web update.

The lockout also prevents the post-update request from running, so `data/update.php` lingers and FreshRSS keeps showing "update pending" - second symptom reported in the same issue.

## Fix

Mirrors the existing `save_custom_themes()` pattern: stage the user's auth files into the new package tree before the wipe, so the subsequent `recurse_copy` restores them. No change to the wipe-and-recopy architecture, no change to orphan cleanup, no rollback logic needed.

File mode is preserved explicitly via `chmod` after `copy()` - matters for `.htpasswd`, where PHP's default `copy()` would otherwise widen 0640 to 0644.

## Limitations

- If FreshRSS ever ships a non-trivial change to the default `p/i/.htaccess`, customized installs will silently keep their old version. Same tradeoff `save_custom_themes` already accepts for `xTheme-*` directories. A proper fix would need a per-release manifest of shipped file hashes (coordinated change in the main FreshRSS repo) - happy to do that as a follow-up if preferred.
- A symlinked `p/i/.htaccess` (uncommon - some admins centrally manage it via symlink) is replaced with a regular file copy. Content is preserved; the symlink relationship is not. Fixing this would require changes to `recurse_copy` or a separate post-deploy restore path; not worth the dual-code-path cost given no reports of this case.

## Testing

Verified in isolation against seven scenarios:
- LDAP case (custom `.htaccess`, no `.htpasswd`)
- Basic-auth case (both files customized)
- Vanilla install (no customization, shipped defaults untouched)
- Full `save → del_tree → recurse_copy` slice end-to-end
- Empty `.htaccess`
- File mode preservation on `.htpasswd` (0640 source → 0640 destination)
- Symlinked `.htaccess` (content preserved, becomes regular file)

`phpcs --standard=phpcs.xml` shows 0 new violations on the changed lines.

Did not run against a live ZIP install.
